### PR TITLE
pymilvus 2.4.5 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,17 +37,21 @@ requirements:
     - ujson >=2.0.0
     - pandas >=1.2.4
     - numpy <1.25.0  # [py<=38]
+    # setuptools required because they import pkg_resources
+    # in client/__init__.py
+    - setuptools >69
+    - setuptools <70.1  # [py<39]
   run_constrained:
     # we release a version of pymilvus without
     # the mandatory dependency to milvus-lite
     # which we make optional
     - milvus-lite >=2.4.0,<2.5.0  # [not win]
-    # setuptools is not a run dependency but
-    # it is pulled in by some other package
-    # and these constraints allow to respect
-    # the ones specified upstream in pyproject.toml
-    - setuptools >69
-    - setuptools <70.1  # [py<39]
+    # other optional dependencies
+    # [bulk_writer]
+    - minio >=7.0.0
+    - pyarrow >=12.0.0
+    # [model]
+    - milvus-model >=0.1.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pymilvus" %}
-{% set version = "1.1.2" %}
-
+{% set version = "2.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -8,41 +7,79 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pymilvus-{{ version }}.tar.gz
-  sha256: 8622233c49aa9d27b84e6ee54f30d6370136a8ef4f2362b95d6499a21f5305c0
+  sha256: 1a497fe9b41d6bf62b1d5e1c412960922dde1598576fcbb8818040c8af11149f
+  patches:
+    - patches/0001-remove-milvus-lite-dependency.patch
+    - patches/0002-remove-grpc_testing-in-conftest.patch
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - pip
-    - python >=3.6
-    - setuptools-scm
+    - python
+    - setuptools-scm >=6.2
+    - setuptools >69
+    - setuptools <70.1  # [py<39]
+    - wheel
     - gitpython
   run:
-    - grpcio >=1.22.0,<1.38.0
-    - grpcio-tools >=1.22.0,<1.38.0
-    - python >=3.6
-    - requests >=2.22.0
+    - python
+    - grpcio >=1.49.1,<=1.63.0
+    - protobuf >=3.20.0
+    - environs <=9.5.0
     - ujson >=2.0.0
-    - mmh3
+    - pandas >=1.2.4
+    - numpy <1.25.0  # [py<=38]
+  run_constrained:
+    # we release a version of pymilvus without
+    # the mandatory dependency to milvus-lite
+    # which we make optional
+    - milvus-lite >=2.4.0,<2.5.0  # [not win]
+    # setuptools is not a run dependency but
+    # it is pulled in by some other package
+    # and these constraints allow to respect
+    # the ones specified upstream in pyproject.toml
+    - setuptools >69
+    - setuptools <70.1  # [py<39]
 
 test:
   imports:
-    - milvus
-    - milvus.client
-  commands:
-    - pip check
+    - pymilvus
+    - pymilvus.client
   requires:
     - pip
+    - pytest
+    - grpcio ==1.62.2
+    - grpcio-tools ==1.62.2
+    # this is not available at the moment
+    # - grpcio-testing ==1.62.2
+  source_files:
+    - tests
+  commands:
+    - pip check
+    # skip test_milvus_lite for milvus-lite (made as optional dependency, not available)
+    # skip test_get_commit because uses git to retrieve a commit id, not interesting
+    # ignore test files which use grpcio-testing (not available)
+    - pytest -vv tests -k "not (test_milvus_lite or test_get_commit)" --ignore=tests/test_grpc_handler.py --ignore=tests/test_create_collection.py
 
 about:
   home: https://github.com/milvus-io/pymilvus
-  summary: Python Sdk for Milvus
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  summary: Python Sdk for Milvus
+  description: |
+    PyMilvus is a Python SDK of Milvus.
+    Its source code is open-sourced and hosted on GitHub.
+  doc_url: https://milvus.io/api-reference/pymilvus/v2.4.x/About.md
+  dev_url: https://github.com/milvus-io/pymilvus
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,14 @@ requirements:
     - setuptools >69
     - setuptools <70.1  # [py<39]
   run_constrained:
+    # As requested by SF, since they do not need
+    # to access local DB files, and because
+    # milvus-lite would require a bigger effort,
     # we release a version of pymilvus without
     # the mandatory dependency to milvus-lite
-    # which we make optional
+    # which we make optional. The SDK and the client
+    # will still be able to connect to any instance
+    # of Milvus over the network.
     - milvus-lite >=2.4.0,<2.5.0  # [not win]
     # other optional dependencies
     # [bulk_writer]

--- a/recipe/patches/0001-remove-milvus-lite-dependency.patch
+++ b/recipe/patches/0001-remove-milvus-lite-dependency.patch
@@ -1,0 +1,24 @@
+From 711d92dfede8f6e6b61e9151163386461e682b4d Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Wed, 14 Aug 2024 18:18:27 +0200
+Subject: [PATCH 1/2] remove milvus-lite dependency
+
+---
+ pyproject.toml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 5ded981..6325f56 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -25,7 +25,6 @@ dependencies=[
+     "ujson>=2.0.0",
+     "pandas>=1.2.4",
+     "numpy<1.25.0;python_version<='3.8'",
+-    "milvus-lite>=2.4.0,<2.5.0;sys_platform!='win32'",
+ ]
+ 
+ classifiers=[
+-- 
+2.39.1
+

--- a/recipe/patches/0002-remove-grpc_testing-in-conftest.patch
+++ b/recipe/patches/0002-remove-grpc_testing-in-conftest.patch
@@ -1,0 +1,37 @@
+From ecb90c332c2d7157623dc38f4730ba0405ede6e9 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Thu, 15 Aug 2024 11:23:46 +0200
+Subject: [PATCH 2/2] remove grpc_testing in conftest
+
+---
+ tests/conftest.py | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 88a7ee9..5aef534 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -1,6 +1,5 @@
+ import sys
+ import pytest
+-import grpc_testing
+ 
+ # https://github.com/grpc/grpc/blob/5918f98ecbf5ace77f30fa97f7fc3e8bdac08e04/src/python/grpcio_tests/tests/testing/_client_test.py
+ from grpc.framework.foundation import logging_pool
+@@ -13,13 +12,6 @@ sys.path.append(dirname(dirname(abspath(__file__))))
+ descriptor = milvus_pb2.DESCRIPTOR.services_by_name['MilvusService']
+ 
+ 
+-@pytest.fixture(scope="function")
+-def channel(request):
+-    channel = grpc_testing.channel([descriptor], grpc_testing.strict_real_time())
+-
+-    return channel
+-
+-
+ @pytest.fixture(scope="function")
+ def client_thread(request):
+     client_execution_thread_pool = logging_pool.pool(2)
+-- 
+2.39.1
+


### PR DESCRIPTION
pymilvus 2.4.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5103]
- dev_url (pypi): https://github.com/milvus-io/pymilvus/tree/v2.4.5
- conda-forge: https://github.com/conda-forge/pymilvus-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/pymilvus/2.4.5
- pypi inspector: https://inspector.pypi.io/project/pymilvus/2.4.5

### Explanation of changes:

- new feedstock
- patches:
  - remove `milvus-lite` dependency
  - remove `grpc_testing` in `conftest.py`


[PKG-5103]: https://anaconda.atlassian.net/browse/PKG-5103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ